### PR TITLE
Prevent cursor from showing up in the scrollbar

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -32,7 +32,7 @@
 ;;
 ;; Differences with the built-in front-end:
 ;;
-;; - Differents colors for differents backends.
+;; - Different colors for differents backends.
 ;; - Icons associated to functions/variables/.. and their backends
 ;; - Display candidate's documentation (support quickhelp-string)
 ;; - Not limited by the current window size, buffer's text properties, ..
@@ -230,9 +230,9 @@ Examples:
   "Return the child frame."
   (frame-parameter nil 'company-box-frame))
 
-(defmacro company-box--set-frame (frame)
+(defsubst company-box--set-frame (frame)
   "Set the frame parameter ‘company-box-frame’ to FRAME."
-  `(set-frame-parameter nil 'company-box-frame ,frame))
+  (set-frame-parameter nil 'company-box-frame frame))
 
 (defun company-box--get-buffer (&optional suffix)
   "Construct the buffer name, it should be unique for each frame."

--- a/company-box.el
+++ b/company-box.el
@@ -551,7 +551,8 @@ It doesn't nothing if a font icon is used."
   (with-current-buffer buffer
     (erase-buffer)
     (setq header-line-format nil
-          mode-line-format nil)
+          mode-line-format nil
+          cursor-in-non-selected-windows nil)
     (unless (zerop height-blank)
       (insert (propertize " " 'display `(space :align-to right-fringe :height ,height-blank))
               (propertize "\n" 'face '(:height 1))))


### PR DESCRIPTION
Last fix for this missed a spot.

I've also replaced the set-frame macro with an inline function, since I assume you wanted that one-liner inlined, and that's what `defsubst` is for.
