### PR TITLE
company-ensure-emulation-alist after showing doc

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -125,7 +125,9 @@
   (setq company-box-doc--timer
         (run-with-idle-timer
          company-box-doc-delay nil
-         (lambda nil (company-box-doc--show selection frame)))))
+         (lambda nil 
+            (company-box-doc--show selection frame)
+            (company-ensure-emulation-alist)))))
 
 (defun company-box-doc--hide (frame)
   (-some-> (frame-parameter frame 'company-box-doc-frame)


### PR DESCRIPTION
Company calls this function at every time when completion starts, to make sure that `company-active-map` take precedence in `emulation-mode-map-alists`. 
I found that in company-box, every time a doc frame pops up, `evil-mode-map-alist` becomes the first element in `emulation-mode-map-alists` and therefore takes precedence, overriding some mappings in `company-active-map`. Calling `company-ensure-emulation-alist` ensure the precedence of `company-active-map`.