### PR TITLE
ac-php company-backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ Notes:
 By default, images are used to display icons.  
 You can also use [font icons](https://github.com/sebastiencs/company-box/wiki/icons)  
 With images, you can't change icons colors
+
+#### Icon backendcs not activated per default
+
+##### ac-php
+
+If you use the `ac-php` company backend, you can activate company-box support by adding
+
+    (add-to-list 'company-box-icons-functions 'company-box-icons--acphp)
+
+to your emacs setup.

--- a/README.md
+++ b/README.md
@@ -38,21 +38,11 @@ See the docstring of the variable `company-box-backends-colors`:
 
 See the variable `company-box-icons-functions`  
 
-For now, there are customs icons for 3 backends only: `company-lsp`, `company-elisp` and `company-yasnippet`.  
+For now, there are customs icons for 4 backends only: `company-lsp`, `company-elisp`, `company-yasnippet` and `company-php`.  
 You can customize their icons with the variables:  
-`company-next-icons-lsp`, `company-next-icons-elisp` and `company-next-icons-yasnippet`
+`company-next-icons-lsp`, `company-next-icons-elisp`, `company-next-icons-yasnippet` and `company-next-icons-acphp`.
 
 Notes:  
 By default, images are used to display icons.  
 You can also use [font icons](https://github.com/sebastiencs/company-box/wiki/icons)  
 With images, you can't change icons colors
-
-#### Icon backendcs not activated per default
-
-##### ac-php
-
-If you use the `ac-php` company backend, you can activate company-box support by adding
-
-    (add-to-list 'company-box-icons-functions 'company-box-icons--acphp)
-
-to your emacs setup.

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -104,6 +104,18 @@ See `company-box-icons-functions' for the ICON format.
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
 specification.md#completion-request-leftwards_arrow_with_hook.")
 
+(defvar company-box-icons-acphp
+  (eval-when-compile
+    `(,(company-box-icons-image "Method.png")
+      ,(company-box-icons-image "Method.png")
+      ,(company-box-icons-image "Field.png")
+      ,(company-box-icons-image "Class.png")
+      ,(company-box-icons-image "Property.png")))
+  "List of icons to use with AC-PHP candidates.
+The list has the form:
+(FUNCTION VALUE FEATURE FACE).
+See `company-box-icons-functions' for each ICON format.")
+
 (defun company-box-icons--lsp (candidate)
   (-when-let* ((lsp-item (get-text-property 0 'lsp-completion-item candidate))
                (kind (gethash "kind" lsp-item)))
@@ -122,6 +134,16 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
 (defun company-box-icons--yasnippet (candidate)
   (when (get-text-property 0 'yas-annotation candidate)
     company-box-icons-yasnippet))
+
+(defun company-box-icons--acphp (candidate)
+  (when (derived-mode-p 'php-mode)
+    (let* ((type-tag (get-text-property 0 'ac-php-tag-type candidate))
+           (item (cond ((equal "m" type-tag) 1)
+                       ((equal "f" type-tag) 0)
+                       ((equal "d" type-tag) 2)
+                       ((equal "p" type-tag) 4)
+                       (t 3))))
+      (nth item company-box-icons-php))))
 
 (provide 'company-box-icons)
 ;;; company-box-icons.el ends here

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -98,7 +98,7 @@ Each element have the form:
 (KIND . ICON)
 
 Where KIND correspond to a number, the CompletionItemKind from the LSP [1]
-
+a
 See `company-box-icons-functions' for the ICON format.
 
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
@@ -106,12 +106,18 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
 
 (defvar company-box-icons-acphp
   (eval-when-compile
-    `(,(company-box-icons-image "Method.png")
-      ,(company-box-icons-image "Method.png")
-      ,(company-box-icons-image "Field.png")
+    `(,(company-box-icons-image "Interface.png")
       ,(company-box-icons-image "Class.png")
-      ,(company-box-icons-image "Property.png")))
-  "List of icons to use with AC-PHP candidates.
+      ,(company-box-icons-image "Method.png")
+      ,(company-box-icons-image "Method.png")
+      ,(company-box-icons-image "Property.png")
+      ,(company-box-icons-image "Constant.png")
+      ,(company-box-icons-image "Field.png")
+      ,(company-box-icons-image "Interface.png")
+      ,(company-box-icons-image "Namespace.png")
+      ,(company-box-icons-image "Template.png")
+      ,(company-box-icons-image "Misc.png")))
+  "List of icons to use with PHP candidates.
 The list has the form:
 (FUNCTION VALUE FEATURE FACE).
 See `company-box-icons-functions' for each ICON format.")
@@ -138,12 +144,17 @@ See `company-box-icons-functions' for each ICON format.")
 (defun company-box-icons--acphp (candidate)
   (when (derived-mode-p 'php-mode)
     (let* ((type-tag (get-text-property 0 'ac-php-tag-type candidate))
-           (item (cond ((equal "m" type-tag) 1)
-                       ((equal "f" type-tag) 0)
-                       ((equal "d" type-tag) 2)
+           (item (cond ((equal "t" type-tag) 0)
+                       ((equal "c" type-tag) 1)
+                       ((equal "m" type-tag) 2)
+                       ((equal "f" type-tag) 3)
                        ((equal "p" type-tag) 4)
-                       (t 3))))
+                       ((equal "d" type-tag) 5)
+                       ((equal "v" type-tag) 6)
+                       ((equal "i" type-tag) 7)
+                       ((equal "n" type-tag) 8)
+                       ((equal "T" type-tag) 9)
+                       (t 10))))
       (nth item company-box-icons-php))))
-
 (provide 'company-box-icons)
 ;;; company-box-icons.el ends here

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -106,20 +106,22 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
 
 (defvar company-box-icons-acphp
   (eval-when-compile
-    `(,(company-box-icons-image "Interface.png")
-      ,(company-box-icons-image "Class.png")
-      ,(company-box-icons-image "Method.png")
-      ,(company-box-icons-image "Method.png")
-      ,(company-box-icons-image "Property.png")
-      ,(company-box-icons-image "Constant.png")
-      ,(company-box-icons-image "Field.png")
-      ,(company-box-icons-image "Interface.png")
-      ,(company-box-icons-image "Namespace.png")
-      ,(company-box-icons-image "Template.png")
-      ,(company-box-icons-image "Misc.png")))
+    `(,(company-box-icons-image "Interface.png") ;; Trait
+      ,(company-box-icons-image "Class.png")     ;; Class
+      ,(company-box-icons-image "Method.png")    ;; Method
+      ,(company-box-icons-image "Method.png")    ;; Function
+      ,(company-box-icons-image "Property.png")  ;; Property
+      ,(company-box-icons-image "Constant.png")  ;; Constant
+      ,(company-box-icons-image "Field.png")     ;; Member/Variable
+      ,(company-box-icons-image "Interface.png") ;; Interface
+      ,(company-box-icons-image "Namespace.png") ;; Namespace
+      ,(company-box-icons-image "Template.png")  ;; Usetrait
+      ,(company-box-icons-image "Misc.png")))    ;; Fallback
   "List of icons to use with PHP candidates.
-The list has the form:
-(FUNCTION VALUE FEATURE FACE).
+
+  The meaning corresponds to the position in this list:
+  (TRAIT CLASS METHOD FUNCTION PROPERTY CONSTANT VARIABLE INTERFACE NAMESPACE USETRAIT FALLBACK)
+  
 See `company-box-icons-functions' for each ICON format.")
 
 (defun company-box-icons--lsp (candidate)

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -98,7 +98,7 @@ Each element have the form:
 (KIND . ICON)
 
 Where KIND correspond to a number, the CompletionItemKind from the LSP [1]
-a
+
 See `company-box-icons-functions' for the ICON format.
 
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\

--- a/company-box.el
+++ b/company-box.el
@@ -121,7 +121,7 @@ To change the number of _visible_ chandidates, see `company-tooltip-limit'"
   :group 'company-box)
 
 (defcustom company-box-icons-functions
-  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--elisp)
+  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--elisp company-box-icons--acphp)
   "Functions to call on each candidate that should return an icon.
 The functions takes 1 parameter, the completion candidate.
 


### PR DESCRIPTION
This adds a few custom icons for php-code when using the ac-php company backend.

The documentation for icon-font support could/should be amended with this snippet, if you accept this PR

      (setq company-box-icons-php
        '((fa_tasks :face font-lock-function-name-face) ;; Trait
         (fa_cube :face font-lock-function-name-face) ;; Class
         (fa_tags :face font-lock-function-name-face) ;; Method
         (fa_tag :face font-lock-function-name-face) ;; Function
         (fa_plus_square :face font-lock-function-name-face) ;; Property
         (fa_bullseye :face font-lock-function-name-face) ;; Constant
         (fa_cog :face font-lock-function-name-face) ;; Variable
         (fa_cubes :face font-lock-variable-name-face) ;; Interface
         (fa_object_group :face font-lock-constant-face) ;; Namespace
         (fa_stop_circle_o :face font-lock-constant-face) ;; Usetrait
         (md_storage :face font-lock-type-face))) ;; 
