### PR TITLE
Don't save childframe with desktop mode

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -201,7 +201,8 @@ Examples:
     (drag-internal-border . t)
     (left-fringe . 0)
     (right-fringe . 0)
-    (no-special-glyphs . t))
+    (no-special-glyphs . t)
+    (desktop-dont-save . t))
   "Frame parameters used to create the frame.")
 
 (defvar-local company-box--ov nil)


### PR DESCRIPTION
Desktop mode sometimes restore the frames out of z-order, but there's no way to push the child frame down the stack, so sometimes after restart I get a blank company-box childframe covering my frame controls. This PR makes sure desktop mode ignores the childframe when saving a session.