### PR TITLE
make frame compatible with windows manager chunkwm

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -107,6 +107,7 @@
                   company-box-frame-parameters))
          (frame (company-box--make-frame buffer)))
     ;; (set-face-background 'internal-border "white" frame)
+    (set-frame-parameter frame 'name "")
     frame))
 
 (defun company-box-doc--show (selection frame)

--- a/company-box.el
+++ b/company-box.el
@@ -257,6 +257,7 @@ Examples:
       (set-frame-parameter nil 'company-box-window window))
     (set-window-dedicated-p window t)
     (redirect-frame-focus frame (frame-parent frame))
+    (set-frame-parameter frame 'name "")
     frame))
 
 (defun company-box--get-ov nil


### PR DESCRIPTION
For macOS window manager chunkwm, it matches window title (frame title in emacs)
to avoid tiling tooltip (which uses empty frame name), thought company-box
should work the same way.