### PR TITLE
Support Common faces

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -434,7 +434,8 @@ It doesn't nothing if a font icon is used."
           (color (company-box--get-color backend))
           ((c-color a-color i-color s-color) (company-box--resolve-colors color))
           (icon-string (and company-box--with-icons-p (company-box--add-icon candidate)))
-          (candidate-string (propertize candidate 'face 'company-box-candidate))
+          (candidate-string (concat (propertize company-common 'face 'company-tooltip-common)
+                                    (substring (propertize candidate 'face 'company-box-candidate) (length company-common) nil)))
           (align-string (when annotation
                           (concat " " (and company-tooltip-align-annotations
                                            (propertize " " 'display `(space :align-to (- right-fringe ,(or len-a 0) 1)))))))

--- a/company-box.el
+++ b/company-box.el
@@ -205,8 +205,10 @@ Examples:
   "Frame parameters used to create the frame.")
 
 (defvar-local company-box--ov nil)
+(defvar-local company-box--ov-common nil)
 (defvar-local company-box--max 0)
 (defvar-local company-box--with-icons-p nil)
+(defvar-local company-box--icon-offset 3)
 (defvar-local company-box--x nil)
 (defvar-local company-box--space nil)
 (defvar-local company-box--start nil)
@@ -263,6 +265,10 @@ Examples:
   (or company-box--ov
       (setq company-box--ov (make-overlay 1 1))))
 
+(defun company-box--get-ov-common nil
+  (or company-box--ov-common
+      (setq company-box--ov-common (make-overlay 1 1))))
+
 (defun company-box--extract-background (color)
   "COLOR can be a string, face or plist."
   `(:background
@@ -281,22 +287,27 @@ It doesn't nothing if a font icon is used."
                (new-image (append image (and color (company-box--extract-background color)))))
     (put-text-property point (1+ point) 'display new-image)))
 
-(defun company-box--update-line (selection)
+(defun company-box--update-line (selection common)
   (company-box--update-image)
   (goto-char 1)
   (forward-line selection)
   (move-overlay (company-box--get-ov)
                 (line-beginning-position)
                 (line-beginning-position 2))
+  (move-overlay (company-box--get-ov-common)
+                (+ company-box--icon-offset (line-beginning-position))
+                (+ 1 (length common) (+ company-box--icon-offset (line-beginning-position))))
   (let ((color (or (get-text-property (point) 'company-box--color)
                    'company-box-selection)))
     (overlay-put (company-box--get-ov) 'face color)
+    (overlay-put (company-box--get-ov-common) 'face 'company-tooltip-common-selection)
     (company-box--update-image color))
   (run-hook-with-args 'company-box-selection-hook selection
                       (or (frame-parent) (selected-frame))))
 
 (defun company-box--render-buffer (string)
-  (let ((selection company-selection))
+  (let ((selection company-selection)
+        (common company-common))
     (with-current-buffer (company-box--get-buffer)
       (erase-buffer)
       (insert string "\n")
@@ -309,7 +320,7 @@ It doesn't nothing if a font icon is used."
       (setq-local scroll-margin  0)
       (setq-local scroll-preserve-screen-position t)
       (add-hook 'window-configuration-change-hook 'company-box--prevent-changes t t)
-      (company-box--update-line selection))))
+      (company-box--update-line selection common))))
 
 (defvar-local company-box--bottom nil)
 
@@ -587,9 +598,10 @@ It doesn't nothing if a font icon is used."
 ;; ;; (message "HEIGHT-S-1: %s HEIGHT-B-1: %s sum: %s" scrollbar-pixels blank-pixels (+ height-scrollbar-1 height-blank-1))
 
 (defun company-box--change-line nil
-  (let ((selection company-selection))
+  (let ((selection company-selection)
+        (common company-common))
     (with-selected-window (get-buffer-window (company-box--get-buffer) t)
-      (company-box--update-line selection))
+      (company-box--update-line selection common))
     (company-box--update-scrollbar (company-box--get-frame))))
 
 (defun company-box--next-line nil


### PR DESCRIPTION
This addresses #43, and adds the faces `company-tooltip-common` and `company-tooltip-common-selection`.

The `company-tooltip-common` commit should be fine. I am not so sure about the second commit, for `company-tooltip-common-selection`. It would currently require setting the value of `company-box--icon-offset` to the appropriate offset value. I am open to suggestions of how best to handle this, whether via `customize` or by somehow calculating this offset.