### PR TITLE
Take line-spacing into account when calculating height

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -346,7 +346,13 @@ It doesn't nothing if a font icon is used."
 
 (defun company-box--set-frame-position (frame)
   (-let* (((left top _right _bottom) (company-box--edges))
-          (char-height (frame-char-height frame))
+          (base-char-height (frame-char-height frame))
+          (buffer (with-selected-frame frame (company-box--get-buffer)))
+          (spacing (buffer-local-value 'line-spacing buffer))
+          (char-height (pcase spacing
+                         ((pred integerp) (+ spacing base-char-height))
+                         ((pred floatp) (round (* (1+ spacing) base-char-height)))
+                         (_ base-char-height)))
           (char-width (frame-char-width frame))
           (height (* (min company-candidates-length company-tooltip-limit) char-height))
           (frame-resize-pixelwise t)


### PR DESCRIPTION
The frame height is calculated in `company-box--set-frame-position` as the character height in pixels multiplied by the number of items. The character height does not include `line-spacing`; this causes the calculated height to be too small.

This PR adds handling of possible non-nil `line-spacing` values.