### PR TITLE
Add: support for eglot lsp items to company-box-icons--lsp function

### DIFF
--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -197,12 +197,18 @@ See `company-box-icons-images' or `company-box-icons-all-the-icons' for the ICON
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
 specification.md#completion-request-leftwards_arrow_with_hook.")
 
+(defun get-lsp-icon (kind-num)
+  (alist-get kind-num company-box-icons--lsp-alist))
+
 (defun company-box-icons--lsp (candidate)
-  (-when-let* ((lsp-item (or (get-text-property 0 'lsp-completion-item candidate)
-                             (get-text-property 0 'eglot--lsp-item candidate)))
-               (kind-num (if (hash-table-p lsp-item) (gethash "kind" lsp-item)
-                           (plist-get lsp-item :kind))))
-    (alist-get kind-num company-box-icons--lsp-alist)))
+  (-when-let* ((lsp-item (get-text-property 0 'lsp-completion-item candidate))
+               (kind-num (gethash "kind" lsp-item)))
+    (get-lsp-icon kind-num)))
+
+(defun company-box-icons--eglot (candidate)
+  (-when-let* ((eglot-item (get-text-property 0 'eglot--lsp-item candidate))
+               (kind-num (plist-get eglot-item :kind)))
+    (get-lsp-icon kind-num)))
 
 (defconst company-box-icons--php-alist
   '(("t" . Interface)

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -198,8 +198,10 @@ See `company-box-icons-images' or `company-box-icons-all-the-icons' for the ICON
 specification.md#completion-request-leftwards_arrow_with_hook.")
 
 (defun company-box-icons--lsp (candidate)
-  (-when-let* ((lsp-item (get-text-property 0 'lsp-completion-item candidate))
-               (kind-num (gethash "kind" lsp-item)))
+  (-when-let* ((lsp-item (or (get-text-property 0 'lsp-completion-item candidate)
+                             (get-text-property 0 'eglot--lsp-item candidate)))
+               (kind-num (if (hash-table-p lsp-item) (gethash "kind" lsp-item)
+                           (plist-get lsp-item :kind))))
     (alist-get kind-num company-box-icons--lsp-alist)))
 
 (defconst company-box-icons--php-alist

--- a/company-box.el
+++ b/company-box.el
@@ -127,7 +127,7 @@ To change the number of _visible_ chandidates, see `company-tooltip-limit'"
   :group 'company-box)
 
 (defcustom company-box-icons-functions
-  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--elisp company-box-icons--acphp)
+  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--eglot company-box-icons--elisp company-box-icons--acphp)
   "Functions to call on each candidate that should return an icon.
 The functions takes 1 parameter, the completion candidate.
 


### PR DESCRIPTION
This adds handling for the completion candidates returned by the LSP client [eglot](https://github.com/joaotavora/eglot). This functionality is essentially the same as the `lsp-mode` completion, leveraging the completion-at-point functions.  Here's an example of the plist returned in an eglot candidtate:

```emacs-lisp
(eglot--lsp-item
 (:label #("DesignTeam" 0 1 (eglot--lsp-item #2))
         :kind 7
         :detail "=> Class<DesignTeam>"
         :data
         (:path "DesignTeam"
                :return_type "Class<DesignTeam>"
                :location
                (:filename "/home/user/path/to/file"
                           :range (:start (:line 16 :character 0) :end (:line 74 :character 3)))
                :deprecated
                :json-false
                :uri "file:////home/user/path/to/file")
         :textEdit
         (:range (:start (:line 36 :character 0) :end (:line 36 :character 9)) :newText "DesignTeam")
         :sortText "0000DesignTeam")
```
I just added an `or` condition to the `when-let` of the existing lsp icons function, and if `lsp-item` is not a hash table, we assume it is a plist like above.

## Screenshot

It works :)

![image](https://user-images.githubusercontent.com/760104/81161921-fbeda580-8f51-11ea-9fd7-97efd6f6da27.png)
