### PR TITLE
Explicitly set header-line-format to nil

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -319,6 +319,7 @@ It doesn't nothing if a font icon is used."
       (erase-buffer)
       (insert string "\n")
       (setq mode-line-format nil
+            header-line-format nil
             display-line-numbers nil
             truncate-lines t
             cursor-in-non-selected-windows nil)


### PR DESCRIPTION
For people who use a header line (having a default `header-line-format`
value), the header line shows up in company box's buffer. This change
explicitly sets the buffer local `header-line-format` to `nil` so that
header line does not show up.