### PR TITLE
Icon support for Elpy

### DIFF
--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -189,7 +189,7 @@ See `company-box-icons-images' or `company-box-icons-all-the-icons' for the ICON
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
 specification.md#completion-request-leftwards_arrow_with_hook.")
 
-(defun company-box-icons--lsp (candidate)
+(defun company-box-icons--lsp (candidate annotation)
   (-when-let* ((lsp-item (get-text-property 0 'lsp-completion-item candidate))
                (kind-num (gethash "kind" lsp-item)))
     (alist-get kind-num company-box-icons--lsp-alist)))
@@ -207,12 +207,13 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
     ("T" . Template))
   "List of icon types to use with PHP candidates.")
 
-(defun company-box-icons--acphp (candidate)
+
+(defun company-box-icons--acphp (candidate annotation)
   (when (derived-mode-p 'php-mode)
     (-> (get-text-property 0 'ac-php-tag-type candidate)
         (alist-get company-box-icons--php-alist))))
 
-(defun company-box-icons--elisp (candidate)
+(defun company-box-icons--elisp (candidate annotation)
   (when (derived-mode-p 'emacs-lisp-mode)
     (let ((sym (intern candidate)))
       ;; we even can move it to (predicate .  kind) alist
@@ -222,9 +223,23 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
             ((boundp sym) 'Variable)
             (t . nil)))))
 
-(defun company-box-icons--yasnippet (candidate)
+(defun company-box-icons--yasnippet (candidate annotation)
   (when (get-text-property 0 'yas-annotation candidate)
     'Template))
 
+(defconst company-box-icons--elpy-alist
+  '(("class" . Class)
+    ("function" . Function)
+    ("keyword" . Keyword)
+    ("instance" . Reference)
+    ("module" . Module)
+    ("statement" . Variable))
+  "List of icon types to use with Elpy Python candidates.")
+
+(defun company-box-icons--elpy (candidate annotation)
+  (when (and (derived-mode-p 'python-mode)
+	         (bound-and-true-p elpy-mode))
+    (alist-get annotation company-box-icons--elpy-alist 'Unknown nil 'string-equal)))
+    
 (provide 'company-box-icons)
 ;;; company-box-icons.el ends here

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -234,7 +234,7 @@ specification.md#completion-request-leftwards_arrow_with_hook.")
   (when (get-text-property 0 'yas-annotation candidate)
     'Template))
 
-defconst company-box-icons--elpy-alist
+(defconst company-box-icons--elpy-alist
   '(("class" . Class)
     ("function" . Function)
     ("keyword" . Keyword)

--- a/company-box.el
+++ b/company-box.el
@@ -126,7 +126,7 @@ To change the number of _visible_ chandidates, see `company-tooltip-limit'"
   :group 'company-box)
 
 (defcustom company-box-icons-functions
-  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--elisp company-box-icons--acphp)
+  '(company-box-icons--yasnippet company-box-icons--lsp company-box-icons--elisp company-box-icons--acphp company-box-icons--elpy)
   "Functions to call on each candidate that should return an icon.
 The functions takes 1 parameter, the completion candidate.
 
@@ -389,16 +389,16 @@ It doesn't nothing if a font icon is used."
     (make-frame-visible (company-box--get-frame)))
   (company-box--update-scrollbar (company-box--get-frame) t))
 
-(defun company-box--get-kind (candidate)
+(defun company-box--get-kind (candidate annotation)
   (let ((list company-box-icons-functions)
         kind)
     (while (and (null kind) list)
-      (setq kind (funcall (car list) candidate))
+      (setq kind (funcall (car list) candidate annotation))
       (pop list))
     (or kind 'Unknown)))
 
-(defun company-box--get-icon (candidate)
-  (let ((icon (alist-get (company-box--get-kind candidate)
+(defun company-box--get-icon (candidate annotation)
+  (let ((icon (alist-get (company-box--get-kind candidate annotation)
                          (symbol-value company-box-icons-alist))))
     (cond ((listp icon)
            (cond ((eq 'image (car icon))
@@ -411,9 +411,9 @@ It doesn't nothing if a font icon is used."
            (icons-in-terminal (or icon 'fa_question_circle)))
           (t icon))))
 
-(defun company-box--add-icon (candidate)
+(defun company-box--add-icon (candidate annotation)
   (concat
-   (company-box--get-icon candidate)
+   (company-box--get-icon candidate annotation)
    (propertize " " 'display `(space :align-to (+ left-fringe ,(if (> company-box--space 2) 3 2))))))
 
 (defun company-box--get-color (backend)
@@ -444,7 +444,7 @@ It doesn't nothing if a font icon is used."
   (-let* (((candidate annotation len-c len-a backend) candidate)
           (color (company-box--get-color backend))
           ((c-color a-color i-color s-color) (company-box--resolve-colors color))
-          (icon-string (and company-box--with-icons-p (company-box--add-icon candidate)))
+          (icon-string (and company-box--with-icons-p (company-box--add-icon candidate annotation)))
           (candidate-string (propertize candidate 'face 'company-box-candidate))
           (align-string (when annotation
                           (concat " " (and company-tooltip-align-annotations


### PR DESCRIPTION
I've added support for https://github.com/jorgenschaefer/elpy . Unfortunately it requires `annotation` parameter in addition to `candidate` to determine what icon to display and this change would probably break people custom icon functions added in `company-box-icons-functions` so I don't know If it can be merged.

I'm kind a beginner in elisp(if it would be in Python/Scala/Java probably I could figure something out) so I don't know if it can be done differently without too much hacks/workarounds and without breaking existing custom configs.

I can imagine that eventually some other company backend would also require `annotation` to determine displayed icon but if you think that it can't be merged I think it would be good to keep this PR/issue for reference for other elpy users that would like to use this branch.