### PR TITLE
Update company-box-show-single-candidate default value

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -121,7 +121,7 @@ To change the number of _visible_ chandidates, see `company-tooltip-limit'"
   :type 'integer
   :group 'company-box)
 
-(defcustom company-box-show-single-candidate nil
+(defcustom company-box-show-single-candidate t
   "Whether or not to display the candidate if there is only one."
   :type 'boolean
   :group 'company-box)


### PR DESCRIPTION
- default nil value is causing confusion when you don't have any other frondends
configured.