### PR TITLE
company-mode: better integration with company-selection

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -43,6 +43,7 @@
 
 (defcustom company-box-doc-delay 0.5
   "The number of seconds to wait before displaying the popup."
+  :type 'number
   :group 'company-box-doc)
 
 (defvar company-box-doc-frame-parameters

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -51,7 +51,7 @@
               :width ,size
               :height ,size))))
 
-(defvar company-box-icons-icons-in-terminal
+(defconst company-box-icons-icons-in-terminal
   '((Unknown fa_question_circle)
     (Text . fa_text_height) ;; Text
     (Method . (fa_tags :face font-lock-function-name-face)) ;; Method
@@ -81,7 +81,7 @@
     (Template . fa_bookmark)) ;; TypeParameter
   )
 
-(defvar company-box-icons-eclipse
+(defconst company-box-icons-eclipse
   (eval-when-compile
     `((Unknown . ,(company-box-icons-image "Namespace.png"))
       (Text . ,(company-box-icons-image "eclipse/text.png"))
@@ -111,7 +111,7 @@
       (TypeParameter . ,(company-box-icons-image "eclipse/typeparameter.png"))
       (Template . ,(company-box-icons-image "eclipse/template.png")))))
 
-(defvar company-box-icons-netbeans
+(defconst company-box-icons-netbeans
   (eval-when-compile
     `((Unknown . ,(company-box-icons-image "Namespace.png"))
       (Text . ,(company-box-icons-image "netbeans/text.png"))
@@ -141,7 +141,7 @@
       (TypeParameter . ,(company-box-icons-image "netbeans/typeparameter.png"))
       (Template . ,(company-box-icons-image "netbeans/template.png")))))
 
-(defvar company-box-icons-images
+(defconst company-box-icons-images
   (eval-when-compile
     `((Unknown . ,(company-box-icons-image "Namespace.png" 14))
       (Text . ,(company-box-icons-image "String.png" 14))
@@ -287,9 +287,11 @@ See `company-box-icons-images' or `company-box-icons-all-the-icons' for the ICON
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
 specification.md#completion-request-leftwards_arrow_with_hook.")
 
+(declare-function lsp-get "ext:lsp-protocol")
+
 (defun company-box-icons--lsp (candidate)
   (-when-let* ((lsp-item (get-text-property 0 'lsp-completion-item candidate))
-               (kind-num (gethash "kind" lsp-item)))
+               (kind-num (lsp-get lsp-item :kind)))
     (alist-get kind-num company-box-icons--lsp-alist)))
 
 (defconst company-box-icons--php-alist


### PR DESCRIPTION
Current `company-box` is not working with `company-tng` (#47) and some of `company` settings like `company-selection-wrap-around` (#100).

This is due to `company-box` implements its own `company-select-*` functions and doesn't update the selection correctly with `company-set-selection`, this PR is to improve that by:
- Not using `company-box`'s `company-select-*` anymore, but instead update the `company-box` buffer and realign the selection with `company-frontend` update command
- Advice `company-select-next` (like what `company-tng` did) so that it will still respect `company-box-max-candidates`. This will also fix #100 
- Properly detect if `company-box` should show selection by advicing `company-fill-properties`, this will ensure `company-tng` work together with `company-box`, fix #47
- Change some `defvar` to `defconst` so icon path will be updated properly when upgrade package.

Here is what it looks like when work with `company-tng`.
![52e149aa-95ab-41a8-8227-bdbf6489a75a](https://user-images.githubusercontent.com/2631472/89400213-8bbc0f00-d74e-11ea-805b-a069011dd35d.gif)

And without `company-tng`
![90ec4792-864e-4ca4-8ee3-12d4a16a821e](https://user-images.githubusercontent.com/2631472/89400356-c0c86180-d74e-11ea-8126-beef053e3c03.gif)

