### PR TITLE
Consider company-box-icon-right-margin when computing frame position

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -623,7 +623,7 @@ It doesn't nothing if a font icon is used."
      `((width . (text-pixels . ,width))
        (height . (text-pixels . ,company-box--height))
        (user-size . t)
-       (left . (+ ,(or new-x company-box--x)))
+       (left . (+ ,(round (or new-x company-box--x))))
        (top . (+ ,company-box--top))
        (user-position . t)
        (right-fringe . 0)

--- a/company-box.el
+++ b/company-box.el
@@ -599,7 +599,7 @@ It doesn't nothing if a font icon is used."
           (x (if (eq company-box-frame-behavior 'point)
                  p-x
                (if company-box--with-icons-p
-                   (- p-x (* char-width (if (= company-box--space 2) 2 3)) space-numbers scrollbar-width)
+                   (- p-x (* char-width (+ company-box-icon-right-margin (if (= company-box--space 2) 2 3))) space-numbers scrollbar-width)
                  (- p-x (if (= company-box--space 0) 0 char-width) space-numbers scrollbar-width)))))
     (setq company-box--x (max (+ x left) 0)
           company-box--top (+ y top)

--- a/company-box.el
+++ b/company-box.el
@@ -855,7 +855,7 @@ It doesn't nothing if a font icon is used."
              (modify-frame-parameters
               frame
               `((width . (text-pixels . ,width))
-                (left . (+ ,(or new-x company-box--x)))))))))
+                (left . (+ ,(round (or new-x company-box--x))))))))))
 
 (defun company-box--percent (a b)
   (/ (float a) (float b)))


### PR DESCRIPTION
Before:
![Screenshot_20200921_165029](https://user-images.githubusercontent.com/29731420/93776938-d32e2a00-fc2c-11ea-993a-e820ef39a6f7.png)

After:
![Screenshot_20200921_165149](https://user-images.githubusercontent.com/29731420/93776951-d6c1b100-fc2c-11ea-8349-6e6c17e16f8e.png)
