### PR TITLE
Add company-box-buffer-hook to run on newly created buffers

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -297,6 +297,10 @@ Examples:
 (defvar company-box-selection-hook nil
   "Hook run when the selection changed.")
 
+(defcustom company-box-buffer-hook nil
+  "Hook run on new company-box buffers."
+  :type 'hook
+  :group 'company-box)
 
 (defalias 'company-box--icons-in-terminal
   (if (require 'icons-in-terminal nil t)
@@ -318,8 +322,11 @@ Examples:
 
 (defun company-box--get-buffer (&optional suffix)
   "Construct the buffer name, it should be unique for each frame."
-  (get-buffer-create
-   (concat " *company-box-" (company-box--get-id) suffix "*")))
+  (let ((buf (get-buffer-create
+              (concat " *company-box-" (company-box--get-id) suffix "*"))))
+    (with-current-buffer buf
+      (run-hooks 'company-box-buffer-hook))
+    buf))
 
 (defun company-box--with-icons-p nil
   (let ((spaces (+ (- (current-column) (string-width company-prefix))


### PR DESCRIPTION
Create hook to run customizations on newly created `company-box` buffers (both the choices buffer and the doc buffer).

Rationale - I use https://github.com/ema2159/centaur-tabs, and don't want tabs to show up in my `company-box` completion popup. The way to do this in Centaur is to enable `centaur-tabs-local-mode` in the buffer. The cleanest way to facilitate this would be either:

a) Create a new mode to run the popup buffers in, add `centaur-tabs-local-mode` to the mode hooks.
b) Add a hook to run upon buffer creation.

I chose b), as it adds less cruft.