### PR TITLE
Respect company-tooltip-width-grow-only

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -149,8 +149,9 @@ just grab the first candidate and press forward."
 
 (defun company-box-doc (selection frame)
   (when company-box-doc-enable
-    (-some-> (frame-local-getq company-box-doc-frame frame)
-      (make-frame-invisible))
+    (if-let ((fr (frame-local-getq company-box-doc-frame frame)))
+        (when (frame-visible-p fr)
+          (make-frame-invisible fr)))
     (when (timerp company-box-doc--timer)
       (cancel-timer company-box-doc--timer))
     (setq company-box-doc--timer

--- a/company-box.el
+++ b/company-box.el
@@ -784,7 +784,8 @@ It doesn't nothing if a font icon is used."
 (defun company-box-show (&optional on-update)
   (unless on-update
     (setq company-box--parent-start (window-start))
-    (add-hook 'window-scroll-functions 'company-box--handle-scroll-parent nil t))
+    (add-hook 'window-scroll-functions 'company-box--handle-scroll-parent nil t)
+    (set-frame-width (company-box--get-frame) company-tooltip-minimum-width))
   (company-box--save)
   (setq company-box--max 0
         company-box--with-icons-p (company-box--with-icons-p))
@@ -839,13 +840,17 @@ It doesn't nothing if a font icon is used."
           (frame (company-box--get-frame (frame-parent)))
           (window (frame-local-getq company-box-window (frame-parent)))
           (char-width (frame-char-width frame))
+          (current-width (* (frame-width frame) char-width))
           ((start . end) (company-box--get-start-end-for-width window win-start))
           (width (+ (company-box--calc-len (window-buffer window) start end char-width)
                     (if (and (eq company-box-scrollbar t) (company-box--scrollbar-p frame)) (* 2 char-width) 0)
                     char-width))
           (width (max (min width
                            (* company-tooltip-maximum-width char-width))
-                      (* company-tooltip-minimum-width char-width)))
+                      (* company-tooltip-minimum-width char-width)
+                      (if company-tooltip-width-grow-only
+                          current-width
+                        0)))
           (diff (abs (- (frame-pixel-width frame) width)))
           (frame-width (frame-pixel-width (frame-parent)))
           (new-x (and (> (+ width company-box--x) frame-width)


### PR DESCRIPTION
Just updated and found out we now check `company-tooltip-width-grow-only` instead of having its own variable, so I had the idea of implementing this, since it looked pretty easy.

Maybe not the most elegant solution (setting the frame width on `company-box-show` especially), and was made pretty fast, so if you'd like to see any modifications, please do say so!