### PR TITLE
ensure no tab-line in frame (fix 149)

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -355,6 +355,9 @@ Examples:
     (set-window-dedicated-p window t)
     (redirect-frame-focus frame (frame-parent frame))
     (set-frame-parameter frame 'name "")
+    (with-selected-frame frame
+      (when (bound-and-true-p tab-bar-mode)
+        (tab-bar-mode -1)))
     frame))
 
 (defun company-box--get-ov nil


### PR DESCRIPTION
Ensure that there are no tabs in created frame.

Fixes #149 