### PR TITLE
avoid costly call to make-frame-invisible

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -147,15 +147,11 @@ resolve ambiguous documentation requests.  Instead of failing we
 just grab the first candidate and press forward."
   (car candidates))
 
-(let ((frame (measure-time (company-box-doc--make-frame (generate-new-buffer "test")))))
-	(measure-time (make-frame-invisible frame))
-	(measure-time (make-frame-visible frame))
-	(measure-time (delete-frame frame)))
-
 (defun company-box-doc (selection frame)
   (when company-box-doc-enable
-    (-some-> (frame-local-getq company-box-doc-frame frame)
-      (make-frame-invisible))
+    (when-let* ((local-frame (frame-local-getq company-box-doc-frame frame))
+                ((frame-visible-p local-frame)))
+      (make-frame-invisible local-frame))
     (when (timerp company-box-doc--timer)
       (cancel-timer company-box-doc--timer))
     (setq company-box-doc--timer

--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -149,8 +149,9 @@ just grab the first candidate and press forward."
 
 (defun company-box-doc (selection frame)
   (when company-box-doc-enable
-    (-some-> (frame-local-getq company-box-doc-frame frame)
-      (make-frame-invisible))
+    (when-let* ((local-frame (frame-local-getq company-box-doc-frame frame))
+                ((frame-visible-p local-frame)))
+      (make-frame-invisible local-frame))
     (when (timerp company-box-doc--timer)
       (cancel-timer company-box-doc--timer))
     (setq company-box-doc--timer

--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -158,7 +158,7 @@ just grab the first candidate and press forward."
           (run-with-timer
            company-box-doc-delay nil
            (lambda nil
-             (company-box-doc--show selection frame)
+             (company-box-doc--show (or selection 1) frame)
              (company-ensure-emulation-alist))))))
 
 (defun company-box-doc--hide (frame)


### PR DESCRIPTION
I noticed that calling this function took ~0.1s, causing a noticeable lag while typing.
Only calling it on visible frames greatly reduced input lag and scrolling lag in the menu.