### PR TITLE
Wrap doc window at edge of frame

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -49,6 +49,11 @@
   :type 'number
   :group 'company-box-doc)
 
+(defcustom company-box-doc-no-wrap nil
+  "Specify whether or not to wrap the documentation box at the edge of the Emacs frame."
+  :type 'boolean
+  :group 'company-box)
+
 (defvar company-box-doc-frame-parameters
   '((internal-border-width . 10))
   "Frame parameters to use on the doc frame.
@@ -77,7 +82,11 @@
           (box-width (frame-pixel-width (company-box--get-frame)))
           (window (frame-root-window frame))
           (frame-resize-pixelwise t)
-          ((width . height) (window-text-pixel-size window nil nil 10000 10000))
+          ((width . height)
+           (if company-box-doc-no-wrap
+               (window-text-pixel-size window nil nil 10000 10000)
+               (window-text-pixel-size window nil nil (- (frame-outer-width) (+ 20 (+ box-width (nth 0 box-position)))) (- (frame-outer-height) 20))
+           ))
           (bottom (+ company-box--bottom (window-pixel-top) (frame-border-width)))
           (x (+ (car box-position) box-width (/ (frame-char-width) 2)))
           (y (cdr box-position))
@@ -109,6 +118,7 @@
               header-line-format nil
               show-trailing-whitespace nil
               cursor-in-non-selected-windows nil)
+        (toggle-truncate-lines -1)
         (current-buffer)))))
 
 (defun company-box-doc--make-frame (buffer)


### PR DESCRIPTION
Fixes #165. Can return to the old behaviour with company-box-doc-no-wrap, but this option can be removed if it's not wanted by anyone.