### PR TITLE
Use line-pixel-height in box height calculations

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -580,7 +580,7 @@ It doesn't nothing if a font icon is used."
                                       (window-tab-line-height)
                                     0))
           (top (+ top window-tab-line-height))
-          (char-height (frame-char-height frame))
+          (char-height (line-pixel-height))
           (char-width (frame-char-width frame))
           (height (* (min company-candidates-length company-tooltip-limit) char-height))
           (space-numbers (if (eq company-show-quick-access 'left) char-width 0))


### PR DESCRIPTION
Meant as a demonstration how the actual line-height can be used in height computations.

Fixes #180

I actually think that if this is acceptable, we should replace other uses of `(frame-char-height)` with `(line-pixel-height)` to get consistent results during calculations.

Changing this will get `line-pixel-height` _for the current window_; not being able to specify which frame and window to ask could be a weakness, but I didn't encounter any issues so far.