### PR TITLE
company-box.el: don't inherit non-existing faces

### DIFF
--- a/company-box.el
+++ b/company-box.el
@@ -73,11 +73,6 @@
   :prefix "company-box-"
   :group 'company)
 
-(define-obsolete-face-alias 'company-box-annotation 'company-tooltip-annotation nil)
-(define-obsolete-face-alias 'company-box-selection 'company-tooltip-selection nil)
-(define-obsolete-face-alias 'company-box-background 'company-tooltip nil)
-(define-obsolete-face-alias 'company-box-candidate 'company-tooltip nil)
-(define-obsolete-face-alias 'company-box-numbers 'company-tooltip nil)
 (make-obsolete-variable 'company-box-max-candidates nil "")
 (make-obsolete-variable 'company-box-tooltip-minimum-width 'company-tooltip-minimum-width nil "")
 (make-obsolete-variable 'company-box-tooltip-maximum-width 'company-tooltip-maximum-width nil "")
@@ -114,6 +109,12 @@ Only the 'background' color is used in this face."
   '((t :inherit company-box-candidate))
   "Face used for numbers when `company-show-quick-access' is used."
   :group 'company-box)
+
+(define-obsolete-face-alias 'company-box-annotation 'company-tooltip-annotation nil)
+(define-obsolete-face-alias 'company-box-selection 'company-tooltip-selection nil)
+(define-obsolete-face-alias 'company-box-background 'company-tooltip nil)
+(define-obsolete-face-alias 'company-box-candidate 'company-tooltip nil)
+(define-obsolete-face-alias 'company-box-numbers 'company-tooltip nil)
 
 (defcustom company-box-color-icon t
   "Whether or not to color icons.


### PR DESCRIPTION
As evident from the function name, `define-obsolete-face-alias` makes one face an alias to another. IOW the old and new faces become the same thing. So when `company-box` later calls "inherit" on the older face, it basically tries to inherit its own face.

Even worse: the new face at the aliasing point wasn't even defined, that ideally should have raised a runtime error. Anyway, fix this by moving the paragraph to after company-box faces declared.

Fixes: https://github.com/sebastiencs/company-box/issues/176
Fixes: https://github.com/sebastiencs/company-box/issues/155