### PR TITLE
Make the frame's top position user configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ Notes:
 By default, images are used to display icons.  
 You can also use [font icons](https://github.com/sebastiencs/company-box/wiki/icons)  
 With images, you can't change icons colors
+
+### Top margin
+
+You can position the frame downwards by setting the variable `company-box-frame-top-margin` to a positive number. This is useful if your base code/text has an enlarged line height, and company box is intruding into the line above. It's also useful, if you're using copilot and want to see a few lines of suggested code unobscured by the company box. See [PR #205](https://github.com/sebastiencs/company-box/pull/205) for details.
+
+You can set the top margin mode-dependent via mode hooks, if you want. E.g. in Doom Emacs:
+
+``` el
+(use-package! company-box
+  :defer t
+  :config
+  (setq-hook! 'prog-mode-hook
+    company-box-frame-top-margin 20)
+  (setq-hook! 'text-mode-hook
+    company-box-frame-top-margin 75)
+)
+```

--- a/company-box.el
+++ b/company-box.el
@@ -204,6 +204,7 @@ character (see `frame-char-width'), set `0.5' to get half width of a character."
 
 (defcustom company-box-frame-top-margin 0
   "Set extra space above the top of the frame, in pixels.
+This is useful if the company box intrudes on the code/text above it.
 For example, set '70' if you're using copilot, to make sure
 the frame doesn't overlap with the first lines of copilot suggestions."
   :type 'number

--- a/company-box.el
+++ b/company-box.el
@@ -202,6 +202,13 @@ character (see `frame-char-width'), set `0.5' to get half width of a character."
   :type 'number
   :group 'company-box)
 
+(defcustom company-box-frame-top-margin 0
+  "Set extra space above the top of the frame, in pixels.
+For example, set '70' if you're using copilot, to make sure
+the frame doesn't overlap with the first lines of copilot suggestions."
+  :type 'number
+  :group 'company-box)
+
 (make-obsolete-variable 'company-box-highlight-prefix nil nil)
 
 (defcustom company-box-highlight-prefix nil
@@ -582,7 +589,7 @@ It doesn't nothing if a font icon is used."
           (window-tab-line-height (if (fboundp 'window-tab-line-height)
                                       (window-tab-line-height)
                                     0))
-          (top (+ top window-tab-line-height))
+          (top (+ top window-tab-line-height company-box-frame-top-margin))
           (char-height (frame-char-height frame))
           (char-width (frame-char-width frame))
           (height (* (min company-candidates-length company-tooltip-limit) char-height))


### PR DESCRIPTION
This is my first lisp PR, so please be gentle ;-).

- I'm using company-box together with [copilot](https://github.com/copilot-emacs/copilot.el). I need to push the top of the company box frame down, so that the company box frame does not mask the first lines of copilot suggestions.
- Even without copilot, using company-box on a base text with enlarged fonts benefits from adding extra vertical space

Without extra top margin:
![image](https://github.com/sebastiencs/company-box/assets/122351/85b18875-75a4-41a3-9c68-87cb2d7d7111)


With extra top margin set to 70:
![image](https://github.com/sebastiencs/company-box/assets/122351/a216b07f-f5d8-47d5-9ff8-fcea21437267)
