### PR TITLE
Fix byte-compilation warnings

### DIFF
--- a/company-box-doc.el
+++ b/company-box-doc.el
@@ -50,7 +50,8 @@
   :group 'company-box-doc)
 
 (defcustom company-box-doc-no-wrap nil
-  "Specify whether or not to wrap the documentation box at the edge of the Emacs frame."
+  "Specify whether or not to wrap the documentation box at the edge of
+ the Emacs frame."
   :type 'boolean
   :group 'company-box-doc)
 

--- a/company-box-icons.el
+++ b/company-box-icons.el
@@ -291,7 +291,8 @@ Each element have the form:
 
 Where KIND correspond to a number, the CompletionItemKind from the LSP [1]
 
-See `company-box-icons-images' or `company-box-icons-all-the-icons' for the ICON-TYPEs
+See `company-box-icons-images' or `company-box-icons-all-the-icons' for
+the ICON-TYPEs
 
 [1] https://github.com/Microsoft/language-server-protocol/blob/gh-pages/\
 specification.md#completion-request-leftwards_arrow_with_hook.")

--- a/company-box.el
+++ b/company-box.el
@@ -164,8 +164,8 @@ An ICON can be either a SYMBOL, an IMAGE, a LIST, a STRING:
 - SYMBOL:  It is the name of the icon (from `company-box--icons-in-terminal').
 - IMAGE:   An image descriptor [1]
            Example: '(image :type png :file \"/path/to/image.png\")
-- LIST:    The list is then `apply' to `company-box--icons-in-terminal' function.
-           Example: '(fa_icon :face some-face :foreground \"red\")
+- LIST:    The list is then `apply' to `company-box--icons-in-terminal'
+           function. Example: '(fa_icon :face some-face :foreground \"red\")
 - STRING:  A simple string which is inserted, should be of length 1
 
 If a function returns nil, it call the next function in the list.

--- a/company-box.el
+++ b/company-box.el
@@ -172,7 +172,7 @@ If a function returns nil, it call the next function in the list.
 If all functions returns nil, `company-box-icons-unknown' is used.
 
 [1] https://www.gnu.org/software/emacs/manual/html_node/elisp/Image-Descriptors.html"
-  :type 'list
+  :type '(repeat symbol)
   :group 'company-box)
 
 (defcustom company-box-scrollbar t

--- a/company-box.el
+++ b/company-box.el
@@ -95,14 +95,14 @@
 
 (defface company-box-background
   '((t :inherit company-tooltip))
-  "Face used for frame's background.
-Only the 'background' color is used in this face."
+  "Face used for frame background.
+Only the `background' color is used in this face."
   :group 'company-box)
 
 (defface company-box-scrollbar
   '((t :inherit company-tooltip-selection))
   "Face used for the scrollbar.
-Only the 'background' color is used in this face."
+Only the `background' color is used in this face."
   :group 'company-box)
 
 (defface company-box-numbers
@@ -163,9 +163,9 @@ An ICON can be either a SYMBOL, an IMAGE, a LIST, a STRING:
 
 - SYMBOL:  It is the name of the icon (from `company-box--icons-in-terminal').
 - IMAGE:   An image descriptor [1]
-           Example: '(image :type png :file \"/path/to/image.png\")
+           Example: \\='(image :type png :file \"/path/to/image.png\")
 - LIST:    The list is then `apply' to `company-box--icons-in-terminal'
-           function. Example: '(fa_icon :face some-face :foreground \"red\")
+           function. Example: \\='(fa_icon :face some-face :foreground \"red\")
 - STRING:  A simple string which is inserted, should be of length 1
 
 If a function returns nil, it call the next function in the list.
@@ -179,8 +179,8 @@ If all functions returns nil, `company-box-icons-unknown' is used.
   "Whether to draw the custom scrollbar or use default scrollbar.
 
 - t means uses the custom scrollbar
-- 'inherit uses same scrollbar than the current frame
-- 'left or 'right puts default scrollbars to the left or right
+- `inherit' uses same scrollbar than the current frame
+- `left' or `right' puts default scrollbars to the left or right
 - nil means draw no scrollbar."
   :type '(choice (const :tag "Custom scrollbar" t)
                  (const :tag "Inherit scrollbar" inherit)
@@ -218,7 +218,7 @@ for both cases."
 
 Each element has the form (BACKEND . COLOR)
 
-BACKEND is the backend's symbol for which the color applies
+BACKEND is the backend symbol for which the color applies
 COLOR can be a LIST or a STRING:
 
 - LIST:    A property list with the following keys:
@@ -238,7 +238,7 @@ COLOR can be a LIST or a STRING:
 
 Examples:
 
-'((company-yasnippet . (:candidate \"yellow\" :annotation some-face))
+\\='((company-yasnippet . (:candidate \"yellow\" :annotation some-face))
   (company-elisp . (:icon \"yellow\" :selected (:background \"orange\"
                                               :foreground \"black\")))
   (company-dabbrev . \"purple\"))")


### PR DESCRIPTION
As modern Emacs supports native compilation, warnings become especially annoying. Let's get rid of them by fixing everything.

There's nothing important actually, just documentation fixes. Still, there were a lot of warnings, so will be nice to have them fixed.